### PR TITLE
Updating keybinds using the default themes key binds from 10.10

### DIFF
--- a/IR_Black.terminal
+++ b/IR_Black.terminal
@@ -281,6 +281,10 @@
 	</data>
 	<key>keyMapBoundKeys</key>
 	<dict>
+		<key>$F702</key>
+		<string>[1;2D</string>
+		<key>$F703</key>
+		<string>[1;2C</string>
 		<key>$F708</key>
 		<string>[25~</string>
 		<key>$F709</key>
@@ -292,19 +296,13 @@
 		<key>$F70C</key>
 		<string>[31~</string>
 		<key>$F70D</key>
-		<string>[22~</string>
+		<string>[32~</string>
 		<key>$F70E</key>
 		<string>[33~</string>
 		<key>$F70F</key>
 		<string>[34~</string>
-		<key>$F729</key>
-		<string>[H</string>
-		<key>$F72B</key>
-		<string>[F</string>
-		<key>$F72C</key>
-		<string>[5~</string>
-		<key>$F72D</key>
-		<string>[6~</string>
+		<key>$F728</key>
+		<string>[3;2~</string>
 		<key>F704</key>
 		<string>OP</string>
 		<key>F705</key>
@@ -347,18 +345,16 @@
 		<string>[34~</string>
 		<key>F728</key>
 		<string>[3~</string>
-		<key>F729</key>
-		<string>[H</string>
-		<key>F72B</key>
-		<string>[F</string>
-		<key>F72C</key>
-		<string>scrollPageUp:</string>
-		<key>F72D</key>
-		<string>scrollPageDown:</string>
 		<key>^F702</key>
-		<string>[5D</string>
+		<string>[1;5D</string>
 		<key>^F703</key>
-		<string>[5C</string>
+		<string>[1;5C</string>
+		<key>^F728</key>
+		<string>[3;5~</string>
+		<key>~F702</key>
+		<string>b</string>
+		<key>~F703</key>
+		<string>f</string>
 		<key>~F704</key>
 		<string>[17~</string>
 		<key>~F705</key>
@@ -389,6 +385,8 @@
 		<string>[33~</string>
 		<key>~F712</key>
 		<string>[34~</string>
+		<key>~^F728</key>
+		<string>[3;5~</string>
 	</dict>
 	<key>magentaColour</key>
 	<data>


### PR DESCRIPTION
The key binds don't seem to do moving by words anymore. I updated the key binds to use the same binds in the Basic theme that ships with OS X.
